### PR TITLE
start downloading the largest file right away with select, matching peerflix

### DIFF
--- a/server/store.js
+++ b/server/store.js
@@ -46,13 +46,10 @@ var store = _.extend(new events.EventEmitter(), {
 
       var e = engine(torrent, options);
       var onready = function () {
-        var index;
-        if (typeof index !== 'number') {
-          index = e.files.reduce(function (a, b) {
-            return a.length > b.length ? a : b
-          })
-          index = e.files.indexOf(index)
-        }
+        var index = e.files.reduce(function (a, b) {
+          return a.length > b.length ? a : b
+        })
+        index = e.files.indexOf(index)
         e.files[index].select();
       }
       store.emit('torrent', infoHash, e);

--- a/server/store.js
+++ b/server/store.js
@@ -45,8 +45,19 @@ var store = _.extend(new events.EventEmitter(), {
       console.log('adding ' + infoHash);
 
       var e = engine(torrent, options);
+      var onready = function () {
+        var index;
+        if (typeof index !== 'number') {
+          index = e.files.reduce(function (a, b) {
+            return a.length > b.length ? a : b
+          })
+          index = e.files.indexOf(index)
+        }
+        e.files[index].select();
+      }
       store.emit('torrent', infoHash, e);
       torrents[infoHash] = e;
+      e.on('ready', onready);
       save();
       callback(null, infoHash);
     });


### PR DESCRIPTION
Peerflix uses file.select() to begin downloading the largest file when the engine is ready. This can be seen here:

https://github.com/mafintosh/peerflix/blob/master/index.js#L36-L48

Select is documented here

https://github.com/mafintosh/torrent-stream#fileselect

This changes the behaviour of peerflix-server, so if you don't want this, I can modify this pull request to have a feature switch that resides in the config file. 

