### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:onbuild
+RUN  npm install -g grunt-cli bower && useradd -m app && chown app:app . -R
+USER app
+RUN  bower install
+VOLUME [ "/tmp/torrent-stream" ]
+EXPOSE 9000


### PR DESCRIPTION
Hi,

this Dockerfile builds a peerflix-server Docker image. I've added my fork to my hub account: https://hub.docker.com/u/fish/peerflix-server

If you're up for it, I'd suggest you sign up as well so you can provide official images.
Using this image is as simple as running:

    docker run -p 9000:9000 fish/peerflix-server

You can always build the image locally by running `docker build -t peerflix-server .` in this repo.