### PR TITLE
Updated Dockerfile to use an alpine (busybox) source.

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -5,4 +5,4 @@ Docker
 
 Make sure that you have write permissions to your destination directory `/tmp/torrent-stream`.
 
-`docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp -d -v /tmp/torrent-stream:/tmp/torrent-stream asapach/peerflix-server`
+`docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp --rm -d -v /tmp/torrent-stream:/tmp/torrent-stream asapach/peerflix-server`

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install -g grunt-cli bower
 
 RUN adduser -D app 
 WORKDIR /home/app
-ADD . .
+COPY . .
 RUN chown app:app /home/app -R
 
 # run as user app from here on

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,22 @@ FROM mhart/alpine-node:5
 # Update latest available packages
 RUN apk update && \
     apk add git && \
-    rm -rf /var/cache/apk/* /tmp/*
-# openvpn bash shadow@testing
+    rm -rf /var/cache/apk/* /tmp/* && \
+    adduser -D app && \
+    mkdir /tmp/torrent-stream && \
+    chown app:app /tmp/torrent-stream && \
+    npm install -g grunt-cli bower
 
-RUN npm install -g grunt-cli bower
-
-RUN adduser -D app 
 WORKDIR /home/app
 COPY . .
 RUN chown app:app /home/app -R
 
 # run as user app from here on
 USER app
-RUN npm install && bower install && grunt build
+RUN npm install && \
+    bower install && \
+    grunt build
 
-RUN mkdir /tmp/torrent-stream && chown app:app /tmp/torrent-stream
 VOLUME [ "/tmp/torrent-stream" ]
 EXPOSE 6881 9000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,25 @@
-FROM node:onbuild
-RUN  npm install -g grunt-cli bower && useradd -m app && chown app:app . -R
+# Alpine is a lightweight Linux
+FROM mhart/alpine-node:5
+
+# Update latest available packages
+RUN apk update && \
+    apk add git && \
+    rm -rf /var/cache/apk/* /tmp/*
+# openvpn bash shadow@testing
+
+RUN npm install -g grunt-cli bower
+
+RUN adduser -D app 
+WORKDIR /home/app
+ADD . .
+RUN chown app:app /home/app -R
+
+# run as user app from here on
 USER app
-RUN  bower install && grunt build
-RUN  mkdir /tmp/torrent-stream && chown app:app /tmp/torrent-stream
+RUN npm install && bower install && grunt build
+
+RUN mkdir /tmp/torrent-stream && chown app:app /tmp/torrent-stream
 VOLUME [ "/tmp/torrent-stream" ]
 EXPOSE 6881 9000
+
+CMD [ "npm", "start" ]


### PR DESCRIPTION
I updated the Dockerfile to use an alpine-linux source, which is based on busybox.
This drastically reduces the image size from 943MB to 296MB.

Updated Docker.md as well to run with --rm to remove the container on exit.