### PR TITLE
add openvpn support with docker

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -1,8 +1,16 @@
 Docker
 ========
 
-`docker pull asapach/peerflix-server`
+`docker pull stefanlendl/peerflix-server`
 
 Make sure that you have write permissions to your destination directory `/tmp/torrent-stream`.
 
-`docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp --rm -d -v /tmp/torrent-stream:/tmp/torrent-stream asapach/peerflix-server`
+`docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp --cap-add=NET_ADMIN \
+--rm -d -v /tmp/torrent-stream:/tmp/torrent-stream \
+-v ~/.config/peerflix-server:/home/app/.config/peerflix-server \
+stefanlendl/peerflix-server`
+
+This Docker image includes openvpn. Add your config to `~/.config/peerflix-server/vpn.ovpn`.
+
+This is so far only tested when accessing through localhost.
+

--- a/Docker.md
+++ b/Docker.md
@@ -11,6 +11,18 @@ Make sure that you have write permissions to your destination directory `/tmp/to
 stefanlendl/peerflix-server`
 
 This Docker image includes openvpn. Add your config to `~/.config/peerflix-server/vpn.ovpn`.
-
 This is so far only tested when accessing through localhost.
 
+systemd
+========
+
+To run the docker container as a system service with systemd install the `peerflix-server.service` unit file to `/etc/systemd/system/`.
+Afterwards reloading the systemd daemon you can start and enable the unit.
+The configuration for peerflix-server needs to be put into `/etc/peerflix-server`. This can be
+adapted by changing the StartExec line in the unit file.
+`
+sudo cp peerflix-server.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl start peerflix-server.service
+sudo systemctl enable peerflix-server.service
+`

--- a/Docker.md
+++ b/Docker.md
@@ -1,14 +1,14 @@
 Docker
 ========
 
-`docker pull stefanlendl/peerflix-server`
+`docker pull asapach/peerflix-server`
 
 Make sure that you have write permissions to your destination directory `/tmp/torrent-stream`.
 
 `docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp --cap-add=NET_ADMIN \
 --rm -d -v /tmp/torrent-stream:/tmp/torrent-stream \
 -v ~/.config/peerflix-server:/home/app/.config/peerflix-server \
-stefanlendl/peerflix-server`
+asapach/peerflix-server`
 
 This Docker image includes openvpn. Add your config to `~/.config/peerflix-server/vpn.ovpn`.
 This is so far only tested when accessing through localhost.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,22 @@
 FROM mhart/alpine-node:5
 
 # Update latest available packages
-RUN apk update && \
-    apk add git && \
+RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk update && \
+    apk add git openvpn bash shadow@testing && \
     rm -rf /var/cache/apk/* /tmp/* && \
-    adduser -D app && \
+    addgroup -S vpn && \
+    mkdir -p /home/app/.config/peerflix-server && \
     mkdir /tmp/torrent-stream && \
-    chown app:app /tmp/torrent-stream && \
     npm install -g grunt-cli bower
 
 WORKDIR /home/app
 COPY . .
-RUN chown app:app /home/app -R
-
-# run as user app from here on
-USER app
 RUN npm install && \
-    bower install && \
+    bower --allow-root install && \
     grunt build
 
 VOLUME [ "/tmp/torrent-stream" ]
 EXPOSE 6881 9000
 
-CMD [ "npm", "start" ]
+CMD [ "/home/app/init.sh" ]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See [REST.md](REST.md)
 
 ## Docker
 
+includes openvpn
 See [Docker.md](Docker.md)
 
 [npm-image]: https://img.shields.io/npm/v/peerflix-server.svg?style=flat

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+VPNCONF=/home/app/.config/peerflix-server/vpn.ovpn
+
+if [[ -e ${VPNCONF} ]]; then
+  mkdir -p /dev/net
+  if [ ! -c /dev/net/tun ]; then
+    mknod /dev/net/tun c 10 200
+  fi
+  sg vpn -c "openvpn --config ${VPNCONF} --daemon"
+  echo "nameserver 8.8.8.8" > /etc/resolv.conf
+fi
+
+npm start
+

--- a/peerflix-server.service
+++ b/peerflix-server.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=peerflix-server container
+Requires=docker.service
+After=docker.service
+
+[Service]
+Restart=always
+ExecStart= /usr/bin/docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp --rm \
+           --cap-add=NET_ADMIN -v /tmp/torrent-stream:/tmp/torrent-stream \
+           -v /etc/peerflix-server/:/home/app/.config/peerflix-server \
+           --name pf_srv peerflix-server
+ExecStop= /usr/bin/docker stop -t 2 pf_srv
+#; /usr/bin/docker rm -f pf_srv
+
+[Install]
+WantedBy=local.target


### PR DESCRIPTION
I added openvpn to the docker container that starts a given openvpn config file `vpn.ovpn` placed in `~/.config/peerflix-server`.
I also added a systemd unit file to enable the server at boot.

(I only tested this on my local machine so far. I will try it remote as soon as I have my vps up and running)