### PR TITLE
fix syntax error Docker.md

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -5,4 +5,8 @@ Docker
 
 Make sure that you have write permissions to your destination directory `/tmp/torrent-stream`.
 
-`docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp --rm -d -v /tmp/torrent-stream:/tmp/torrent-stream asapach/peerflix-server`
+`docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp -d -v /tmp/torrent-stream:/tmp/torrent-stream asapach/peerflix-server`
+
+Or
+
+`docker run -p 9000:9000 -p 6881:6881 -p 6881:6881/udp --rm -v /tmp/torrent-stream:/tmp/torrent-stream asapach/peerflix-server`


### PR DESCRIPTION
"Conflicting options: --rm and -d"
'--rm' and '-d' cannot be used at the same time.