### PR TITLE
Add ffmpeg into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM mhart/alpine-node:6
 
 # Update latest available packages
 RUN apk update && \
+    apk add ffmpeg && \
     apk add git && \
     rm -rf /var/cache/apk/* /tmp/* && \
     adduser -D app && \


### PR DESCRIPTION
A naive way - just to add ffmpeg into image is works. But it has some issues with calling code.

#122 

The problem with function which calls ffmpeg:
```  function remux() {
    res.type('video/webm');
    var command = ffmpeg(file.createReadStream())
      .videoCodec('libvpx').audioCodec('libvorbis').format('webm')
      .audioBitrate(128)
      .videoBitrate(1024)
      .outputOptions([
        //'-threads 2',
        '-deadline realtime',
        '-error-resilient 1'
      ])
```

It's actually not only remuxing, but also transcoding audio and video with specified bitrates and only on single core which is likely can't be done in realtime even on high end systems without HW acceleration.

I'll open separate issue for this, and also proposes for different links for remuxed variants in #19 is pretty meaningful to implement.