### PR TITLE
Support for M3U with reverse proxy and https

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -143,11 +143,13 @@ api.get('/torrents/:infoHash/stats', findTorrent, function (req, res) {
 
 api.get('/torrents/:infoHash/files', findTorrent, function (req, res) {
   var torrent = req.torrent;
+  var proto = req.get('x-forwarded-proto');
+  if (!proto) { proto=req.protocol; }
   res.setHeader('Content-Type', 'application/x-mpegurl; charset=utf-8');
   res.attachment(torrent.torrent.name + '.m3u');
   res.send('#EXTM3U\n' + torrent.files.map(function (f) {
       return '#EXTINF:-1,' + f.path + '\n' +
-        req.protocol + '://' + req.get('host') + '/torrents/' + torrent.infoHash + '/files/' + encodeURIComponent(f.path);
+        proto + '://' + req.get('host') + '/torrents/' + torrent.infoHash + '/files/' + encodeURIComponent(f.path);
     }).join('\n'));
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -144,8 +144,7 @@ api.get('/torrents/:infoHash/stats', findTorrent, function (req, res) {
 api.get('/torrents/:infoHash/files', findTorrent, function (req, res) {
   var torrent = req.torrent;
   var proto = req.get('x-forwarded-proto') || req.protocol;
-  var host = req.get('x-Forwarded-host') || req.get('host');
-  if (!proto) { proto=req.protocol; }
+  var host = req.get('x-forwarded-host') || req.get('host');
   res.setHeader('Content-Type', 'application/x-mpegurl; charset=utf-8');
   res.attachment(torrent.torrent.name + '.m3u');
   res.send('#EXTM3U\n' + torrent.files.map(function (f) {

--- a/server/index.js
+++ b/server/index.js
@@ -143,13 +143,14 @@ api.get('/torrents/:infoHash/stats', findTorrent, function (req, res) {
 
 api.get('/torrents/:infoHash/files', findTorrent, function (req, res) {
   var torrent = req.torrent;
-  var proto = req.get('x-forwarded-proto');
+  var proto = req.get('x-forwarded-proto') || req.protocol;
+  var host = req.get('x-Forwarded-host') || req.get('host');
   if (!proto) { proto=req.protocol; }
   res.setHeader('Content-Type', 'application/x-mpegurl; charset=utf-8');
   res.attachment(torrent.torrent.name + '.m3u');
   res.send('#EXTM3U\n' + torrent.files.map(function (f) {
       return '#EXTINF:-1,' + f.path + '\n' +
-        proto + '://' + req.get('host') + '/torrents/' + torrent.infoHash + '/files/' + encodeURIComponent(f.path);
+        proto + '://' + host + '/torrents/' + torrent.infoHash + '/files/' + encodeURIComponent(f.path);
     }).join('\n'));
 });
 


### PR DESCRIPTION
When downloading M3U files, if the reverse proxy exposes https, the generated URL is exporting the wrong protocol.
This change checks for x-forwarded-proto in the original request and creates the M3U list with the proxy reported protocol.

To allow for this to work with NGINX it sufficent to add the following lines:

                proxy_set_header Host $http_host;
                proxy_set_header X-Forwarded-Proto https;

The first line let peerflix know the original exposed FQDN:PORT name the client used to reach the proxy, the second header let peerflix know that request was https and not http.