### PR TITLE
Magnet link from hash only

### DIFF
--- a/server/store.js
+++ b/server/store.js
@@ -34,7 +34,7 @@ function save() {
 var store = _.extend(new events.EventEmitter(), {
   add: function (link, callback) {
     if (typeof link === "string")
-      if (link.match(/(\w+)/))
+      if (link.match(/^(\w+)$/))
         link = `magnet:?xt=urn:btih:${link}`
 
     readTorrent(link, function (err, torrent) {

--- a/server/store.js
+++ b/server/store.js
@@ -33,6 +33,10 @@ function save() {
 
 var store = _.extend(new events.EventEmitter(), {
   add: function (link, callback) {
+    if (typeof link === "string")
+      if (link.match(/(\w+)/))
+        link = `magnet:?xt=urn:btih:${link}`
+
     readTorrent(link, function (err, torrent) {
       if (err) {
         return callback(err);

--- a/server/store.js
+++ b/server/store.js
@@ -34,7 +34,7 @@ function save() {
 var store = _.extend(new events.EventEmitter(), {
   add: function (link, callback) {
     if (typeof link === "string")
-      if (link.match(/^(\w+)$/))
+      if (link.match(/^\w{32}$|^\w{40}$/))
         link = `magnet:?xt=urn:btih:${link}`
 
     readTorrent(link, function (err, torrent) {


### PR DESCRIPTION
Sometimes it's just easier to copy/paste a torrent's hash than it's full magnet URL (mostly on mobile devices).

This PR allows a hash to be dropped in the input and a valid magnet link will be generated and passed to `read-torrent`. 

An added benefit of doing so is that it will use the trackers users pass in the options file instead of the trackers usually added to the magnet file by various sites.

Other types of links / uploads aren't affected.

**Example:** Pasting this `08ada5a7a6183aae1e09d831df6748d566095a10` will retrieve the torrents metadata and start the download the same way it would if you pasted this:

`magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent`

**The example is using WebTorrent.io's "Sintel" torrent**